### PR TITLE
refactor: types split

### DIFF
--- a/packages/button/CHANGELOG.md
+++ b/packages/button/CHANGELOG.md
@@ -7,45 +7,27 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @atlantis-lab/button
 
-
-
-
-
 ## [1.3.2](https://github.com/Atlantis-Lab/uikit/compare/@atlantis-lab/button@1.3.1...@atlantis-lab/button@1.3.2) (2020-05-26)
 
 **Note:** Version bump only for package @atlantis-lab/button
-
-
-
-
 
 ## [1.3.1](https://github.com/Atlantis-Lab/uikit/compare/@atlantis-lab/button@1.3.0...@atlantis-lab/button@1.3.1) (2020-05-25)
 
 **Note:** Version bump only for package @atlantis-lab/button
 
-
-
-
-
 # 1.3.0 (2020-05-25)
-
 
 ### Bug Fixes
 
-* packages config update ([b07017f](https://github.com/Atlantis-Lab/uikit/commit/b07017fc2ab910122597074bd77ccd9a18f81ae6))
-* **button:** fix deps ([5ecac8c](https://github.com/Atlantis-Lab/uikit/commit/5ecac8cc043cee2406d4befdd3153a696909ea64))
-* **button:** fix import filetype ([3c53d0a](https://github.com/Atlantis-Lab/uikit/commit/3c53d0ade9d95f6a8ddbf5177a03bf0c1b0196b4))
-* **types:** add @types/react ([dc0e9d2](https://github.com/Atlantis-Lab/uikit/commit/dc0e9d221985ab2a8e17649b3a9c6ff0ad7d4946))
-
+- packages config update ([b07017f](https://github.com/Atlantis-Lab/uikit/commit/b07017fc2ab910122597074bd77ccd9a18f81ae6))
+- **button:** fix deps ([5ecac8c](https://github.com/Atlantis-Lab/uikit/commit/5ecac8cc043cee2406d4befdd3153a696909ea64))
+- **button:** fix import filetype ([3c53d0a](https://github.com/Atlantis-Lab/uikit/commit/3c53d0ade9d95f6a8ddbf5177a03bf0c1b0196b4))
+- **types:** add @types/react ([dc0e9d2](https://github.com/Atlantis-Lab/uikit/commit/dc0e9d221985ab2a8e17649b3a9c6ff0ad7d4946))
 
 ### Features
 
-* **button:** init ([f7ce352](https://github.com/Atlantis-Lab/uikit/commit/f7ce352d44372bf8efd27df54e8d4a927fa81a62)), closes [#2](https://github.com/Atlantis-Lab/uikit/issues/2)
-* **icons:** init icons module ([d51a2f4](https://github.com/Atlantis-Lab/uikit/commit/d51a2f41e156b75f5c19334aeebd262c4428b13e))
-
-
-
-
+- **button:** init ([f7ce352](https://github.com/Atlantis-Lab/uikit/commit/f7ce352d44372bf8efd27df54e8d4a927fa81a62)), closes [#2](https://github.com/Atlantis-Lab/uikit/issues/2)
+- **icons:** init icons module ([d51a2f4](https://github.com/Atlantis-Lab/uikit/commit/d51a2f41e156b75f5c19334aeebd262c4428b13e))
 
 # 1.2.0 (2020-05-25)
 

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@atlantis-lab/button",
+  "repository": "git@github.com:Atlantis-Lab/uikit.git",
   "version": "1.3.3",
   "license": "MIT",
   "main": "dist/index.js",
   "source": "src/index.ts",
+  "typings": "dist/types.d.ts",
   "files": [
     "dist"
   ],
@@ -29,10 +31,6 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:Atlantis-Lab/uikit.git"
   },
   "gitHead": "9cf09561b0c03acd463041d1495c7683c1fac8b0"
 }

--- a/packages/carousel/CHANGELOG.md
+++ b/packages/carousel/CHANGELOG.md
@@ -7,36 +7,22 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @atlantis-lab/carousel
 
-
-
-
-
 ## [0.3.1](https://github.com/Atlantis-Lab/uikit/compare/@atlantis-lab/carousel@0.3.0...@atlantis-lab/carousel@0.3.1) (2020-05-25)
 
 **Note:** Version bump only for package @atlantis-lab/carousel
 
-
-
-
-
 # 0.3.0 (2020-05-25)
-
 
 ### Bug Fixes
 
-* packages config update ([b07017f](https://github.com/Atlantis-Lab/uikit/commit/b07017fc2ab910122597074bd77ccd9a18f81ae6))
-* **carousel:** rearrange deps ([9ae5079](https://github.com/Atlantis-Lab/uikit/commit/9ae5079446459fe3712db0c9b76d78aea6c1e66f))
-* fix build steps ([f8d4c15](https://github.com/Atlantis-Lab/uikit/commit/f8d4c1503295e7b35713fb5dc30e46e65d712aa1))
-* **carousel:** try with deps ([1e5f327](https://github.com/Atlantis-Lab/uikit/commit/1e5f3279b38e07112fe1ed4fc16242e6b015622d))
-
+- packages config update ([b07017f](https://github.com/Atlantis-Lab/uikit/commit/b07017fc2ab910122597074bd77ccd9a18f81ae6))
+- **carousel:** rearrange deps ([9ae5079](https://github.com/Atlantis-Lab/uikit/commit/9ae5079446459fe3712db0c9b76d78aea6c1e66f))
+- fix build steps ([f8d4c15](https://github.com/Atlantis-Lab/uikit/commit/f8d4c1503295e7b35713fb5dc30e46e65d712aa1))
+- **carousel:** try with deps ([1e5f327](https://github.com/Atlantis-Lab/uikit/commit/1e5f3279b38e07112fe1ed4fc16242e6b015622d))
 
 ### Features
 
-* **carousel:** init carousel ([48ae14f](https://github.com/Atlantis-Lab/uikit/commit/48ae14fb76451950687770bc9cadc6c405adc84d))
-
-
-
-
+- **carousel:** init carousel ([48ae14f](https://github.com/Atlantis-Lab/uikit/commit/48ae14fb76451950687770bc9cadc6c405adc84d))
 
 # 0.2.0 (2020-05-25)
 

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@atlantis-lab/carousel",
+  "repository": "git@github.com:Atlantis-Lab/uikit.git",
   "version": "0.3.2",
   "license": "MIT",
   "main": "dist/index.js",
   "source": "src/index.ts",
+  "typings": "dist/types.d.ts",
   "files": [
     "dist"
   ],
@@ -25,13 +27,11 @@
     "styled-tools": "^1.7.0"
   },
   "devDependencies": {
+    "@atlantis-lab/icons": "0.3.2",
+    "@atlantis-lab/utils": "0.4.2",
     "@types/styled-system": "5.1.4"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:Atlantis-Lab/uikit.git"
   }
 }

--- a/packages/carousel/src/Carousel.tsx
+++ b/packages/carousel/src/Carousel.tsx
@@ -8,10 +8,7 @@ import { ArrowBackwardIcon, ArrowForwardIcon } from '@atlantis-lab/icons'
 import { contentWidth, widthWithMargin }       from '@atlantis-lab/utils'
 
 import { SlideButton }                         from './SlideButton'
-
-interface CarouselProps {
-  transition: boolean
-}
+import { CarouselProps }                       from './types'
 
 const transition = ifProp('transition', { transition: '0.3s' })
 

--- a/packages/carousel/src/types.ts
+++ b/packages/carousel/src/types.ts
@@ -1,0 +1,3 @@
+export interface CarouselProps {
+  transition: boolean
+}

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -7,35 +7,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @atlantis-lab/icons
 
-
-
-
-
 ## [0.3.1](https://github.com/Atlantis-Lab/uikit/compare/@atlantis-lab/icons@0.3.0...@atlantis-lab/icons@0.3.1) (2020-05-25)
 
 **Note:** Version bump only for package @atlantis-lab/icons
 
-
-
-
-
 # 0.3.0 (2020-05-25)
-
 
 ### Bug Fixes
 
-* fix build steps ([f8d4c15](https://github.com/Atlantis-Lab/uikit/commit/f8d4c1503295e7b35713fb5dc30e46e65d712aa1))
-* fix deps and paths ([528fcc3](https://github.com/Atlantis-Lab/uikit/commit/528fcc32ae173b10e2cf3f6b0dbd7a5f687b834f))
-* packages config update ([b07017f](https://github.com/Atlantis-Lab/uikit/commit/b07017fc2ab910122597074bd77ccd9a18f81ae6))
-
+- fix build steps ([f8d4c15](https://github.com/Atlantis-Lab/uikit/commit/f8d4c1503295e7b35713fb5dc30e46e65d712aa1))
+- fix deps and paths ([528fcc3](https://github.com/Atlantis-Lab/uikit/commit/528fcc32ae173b10e2cf3f6b0dbd7a5f687b834f))
+- packages config update ([b07017f](https://github.com/Atlantis-Lab/uikit/commit/b07017fc2ab910122597074bd77ccd9a18f81ae6))
 
 ### Features
 
-* **icons:** init icons module ([d51a2f4](https://github.com/Atlantis-Lab/uikit/commit/d51a2f41e156b75f5c19334aeebd262c4428b13e))
-
-
-
-
+- **icons:** init icons module ([d51a2f4](https://github.com/Atlantis-Lab/uikit/commit/d51a2f41e156b75f5c19334aeebd262c4428b13e))
 
 # 0.2.0 (2020-05-25)
 

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@atlantis-lab/icons",
+  "repository": "git@github.com:Atlantis-Lab/uikit.git",
   "version": "0.3.2",
   "license": "MIT",
   "main": "dist/index.js",
   "source": "src/index.ts",
+  "typings": "dist/index.d.ts",
   "files": [
     "dist"
   ],
@@ -16,10 +18,10 @@
     "prepack": "pubflow store",
     "postpack": "pubflow restore"
   },
-  "dependencies": {
+  "peerDependencies": {
+    "react": "^16.9.0",
     "@monstrs/prettier-config": "^0.1.0 || ^0.2.0",
-    "prettier": "^1.18.0",
-    "react": "16.12.0"
+    "prettier": "^1.18.0"
   },
   "devDependencies": {
     "@monstrs/publish-flow": "^0.1.3",
@@ -27,14 +29,11 @@
     "camelcase": "5.3.1",
     "fs-extra-promise": "1.0.1",
     "glob-promise": "3.4.0",
+    "react": "16.12.0",
     "ts-node": "8.5.2"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:Atlantis-Lab/uikit.git"
   },
   "gitHead": "9cf09561b0c03acd463041d1495c7683c1fac8b0"
 }

--- a/packages/icons/tsconfig.compile.json
+++ b/packages/icons/tsconfig.compile.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@monstrs/tsconfig/tsconfig.lib.json"
+  "extends": "@monstrs/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  }
 }

--- a/packages/slideshow/CHANGELOG.md
+++ b/packages/slideshow/CHANGELOG.md
@@ -7,33 +7,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @atlantis-lab/slideshow
 
-
-
-
-
 ## [0.3.1](https://github.com/Atlantis-Lab/uikit/compare/@atlantis-lab/slideshow@0.3.0...@atlantis-lab/slideshow@0.3.1) (2020-05-25)
 
 **Note:** Version bump only for package @atlantis-lab/slideshow
 
-
-
-
-
 # 0.3.0 (2020-05-25)
-
 
 ### Bug Fixes
 
-* packages config update ([b07017f](https://github.com/Atlantis-Lab/uikit/commit/b07017fc2ab910122597074bd77ccd9a18f81ae6))
-
+- packages config update ([b07017f](https://github.com/Atlantis-Lab/uikit/commit/b07017fc2ab910122597074bd77ccd9a18f81ae6))
 
 ### Features
 
-* **slideshow:** slideshow init ([494b065](https://github.com/Atlantis-Lab/uikit/commit/494b065b907c41deaa481a86e2a9bb94dc089c9d))
-
-
-
-
+- **slideshow:** slideshow init ([494b065](https://github.com/Atlantis-Lab/uikit/commit/494b065b907c41deaa481a86e2a9bb94dc089c9d))
 
 # 0.2.0 (2020-05-25)
 

--- a/packages/slideshow/package.json
+++ b/packages/slideshow/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@atlantis-lab/slideshow",
+  "repository": "git@github.com:Atlantis-Lab/uikit.git",
   "version": "0.3.2",
   "license": "MIT",
   "main": "dist/index.js",
@@ -23,14 +24,11 @@
     "styled-tools": "^1.7.0"
   },
   "devDependencies": {
+    "@atlantis-lab/utils": "0.4.2",
     "@types/styled-system": "5.1.4"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:Atlantis-Lab/uikit.git"
   },
   "gitHead": "88d7a3f00297b2b7c15c39390358ebf250512687"
 }

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -7,35 +7,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @atlantis-lab/utils
 
-
-
-
-
 ## [0.4.1](https://github.com/Atlantis-Lab/uikit/compare/@atlantis-lab/utils@0.4.0...@atlantis-lab/utils@0.4.1) (2020-05-25)
 
 **Note:** Version bump only for package @atlantis-lab/utils
 
-
-
-
-
 # 0.4.0 (2020-05-25)
-
 
 ### Bug Fixes
 
-* fix deps and paths ([528fcc3](https://github.com/Atlantis-Lab/uikit/commit/528fcc32ae173b10e2cf3f6b0dbd7a5f687b834f))
-* packages config update ([b07017f](https://github.com/Atlantis-Lab/uikit/commit/b07017fc2ab910122597074bd77ccd9a18f81ae6))
-
+- fix deps and paths ([528fcc3](https://github.com/Atlantis-Lab/uikit/commit/528fcc32ae173b10e2cf3f6b0dbd7a5f687b834f))
+- packages config update ([b07017f](https://github.com/Atlantis-Lab/uikit/commit/b07017fc2ab910122597074bd77ccd9a18f81ae6))
 
 ### Features
 
-* **icons:** init icons module ([d51a2f4](https://github.com/Atlantis-Lab/uikit/commit/d51a2f41e156b75f5c19334aeebd262c4428b13e))
-* **utils:** init ([1088003](https://github.com/Atlantis-Lab/uikit/commit/108800370441f34e5b455a133ee3030f66a6ea1e))
-
-
-
-
+- **icons:** init icons module ([d51a2f4](https://github.com/Atlantis-Lab/uikit/commit/d51a2f41e156b75f5c19334aeebd262c4428b13e))
+- **utils:** init ([1088003](https://github.com/Atlantis-Lab/uikit/commit/108800370441f34e5b455a133ee3030f66a6ea1e))
 
 # 0.3.0 (2020-05-25)
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@atlantis-lab/utils",
+  "repository": "git@github.com:Atlantis-Lab/uikit.git",
   "version": "0.4.2",
   "license": "MIT",
   "main": "dist/index.js",
   "source": "src/index.ts",
+  "typings": "dist/types.d.ts",
   "files": [
     "dist"
   ],
@@ -23,10 +25,6 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:Atlantis-Lab/uikit.git"
   },
   "gitHead": "9cf09561b0c03acd463041d1495c7683c1fac8b0"
 }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,0 +1,6 @@
+export interface WindowDimensions {
+  innerWidth: number | null
+  innerHeight: number | null
+  outerWidth: number | null
+  outerHeight: number | null
+}

--- a/packages/utils/src/useWindowSize.ts
+++ b/packages/utils/src/useWindowSize.ts
@@ -1,11 +1,6 @@
 import { useEffect, useState } from 'react'
 
-interface WindowDimensions {
-  innerWidth: number | null
-  innerHeight: number | null
-  outerWidth: number | null
-  outerHeight: number | null
-}
+import { WindowDimensions }    from './types'
 
 const initialValue: WindowDimensions = {
   innerWidth: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,13 +1652,6 @@
   dependencies:
     "@monstrs/prettier-plugin-import-sort" "0.2.0"
 
-"@monstrs/prettier-config@^0.1.0 || ^0.2.0":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@monstrs/prettier-config/-/prettier-config-0.2.2.tgz#f8eac70485b84af782e0994fd32762a5493b2e06"
-  integrity sha512-hd8s74oRFwuSlpQB3LWM4aNQOcD7tqHDz7ovWGY8dG+2sOPmUj6D0JokQC/QPjj1Gbq8+YSi7Dpl6KQ9XMOUDQ==
-  dependencies:
-    "@monstrs/prettier-plugin-import-sort" "0.2.0"
-
 "@monstrs/prettier-plugin-import-sort@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@monstrs/prettier-plugin-import-sort/-/prettier-plugin-import-sort-0.2.0.tgz#e5a4571f8a0969c1cac0caab1248a6447769353c"
@@ -8804,7 +8797,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.19.1, prettier@^1.18.0:
+prettier@1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==


### PR DESCRIPTION
affects: @atlantis-lab/button, @atlantis-lab/carousel, @atlantis-lab/icons, @atlantis-lab/slideshow,
@atlantis-lab/utils

package update
deps rearrange